### PR TITLE
Add time threshold parameter and implement timestamp handling for pointcloud fusion

### DIFF
--- a/include/pointcloud_concatenate/pointcloud_concatenate.hpp
+++ b/include/pointcloud_concatenate/pointcloud_concatenate.hpp
@@ -33,7 +33,7 @@ public:
   double getHz();
 
   // Public variables and objects
-  
+
 private:
   // Private functions
   void subCallbackCloudIn1(sensor_msgs::PointCloud2 msg);
@@ -41,7 +41,8 @@ private:
   void subCallbackCloudIn3(sensor_msgs::PointCloud2 msg);
   void subCallbackCloudIn4(sensor_msgs::PointCloud2 msg);
   void publishPointcloud(sensor_msgs::PointCloud2 cloud);
-
+  bool checkTimeThreshold(ros::Time& reference_time, ros::Time& current_time, const int& cloud_index);
+  void concatenate_with_reference_cloud(sensor_msgs::PointCloud2& reference_cloud, const sensor_msgs::PointCloud2 cloud_to_concat, bool& success, bool& cloud_received_recent, ros::Time& reference_time, ros::Time& current_time, const int& cloud_index, const bool& update_reference_time = false);
   // Private variables and objects
   ros::NodeHandle nh_;
   std::string node_name_;
@@ -50,7 +51,7 @@ private:
   std::string param_frame_target_;
   int param_clouds_;
   double param_hz_;
-
+  double param_time_threshold_;
   // Publisher and subscribers
   ros::Subscriber sub_cloud_in1 = nh_.subscribe("cloud_in1", 1, &PointcloudConcatenate::subCallbackCloudIn1, this);
   ros::Subscriber sub_cloud_in2 = nh_.subscribe("cloud_in2", 1, &PointcloudConcatenate::subCallbackCloudIn2, this);
@@ -73,6 +74,10 @@ private:
   bool cloud_in2_received_recent = false;
   bool cloud_in3_received_recent = false;
   bool cloud_in4_received_recent = false;
+  ros::Time cloud_in1_timestamp = ros::Time::now();
+  ros::Time cloud_in2_timestamp = ros::Time::now();
+  ros::Time cloud_in3_timestamp = ros::Time::now();
+  ros::Time cloud_in4_timestamp = ros::Time::now();
 
   // Initialization tf2 listener
   boost::shared_ptr<tf2_ros::Buffer> tfBuffer;

--- a/include/pointcloud_concatenate/pointcloud_concatenate.hpp
+++ b/include/pointcloud_concatenate/pointcloud_concatenate.hpp
@@ -41,7 +41,7 @@ private:
   void subCallbackCloudIn3(sensor_msgs::PointCloud2 msg);
   void subCallbackCloudIn4(sensor_msgs::PointCloud2 msg);
   void publishPointcloud(sensor_msgs::PointCloud2 cloud);
-  bool checkTimeThreshold(ros::Time& reference_time, ros::Time& current_time, const int& cloud_index);
+  bool checkTimeThresholdOk(ros::Time& reference_time, ros::Time& current_time, const int& cloud_index);
   void concatenate_with_reference_cloud(sensor_msgs::PointCloud2& reference_cloud, const sensor_msgs::PointCloud2 cloud_to_concat, bool& success, bool& cloud_received_recent, ros::Time& reference_time, ros::Time& current_time, const int& cloud_index, const bool& update_reference_time = false);
   // Private variables and objects
   ros::NodeHandle nh_;

--- a/launch/concat.launch
+++ b/launch/concat.launch
@@ -9,9 +9,10 @@
 
   <!-- Launch PointCloud2 concatenator node -->
   <node pkg="pointcloud_concatenate" type="pointcloud_concatenate_node" name="pc_concat" output="screen">
-    <param name="target_frame" value="$(arg target_frame)" />    
+    <param name="target_frame" value="$(arg target_frame)" />
     <param name="clouds" value="3" />
     <param name="hz" value="10" />
+    <param name="time_threshold" value="0.1" />
     <remap from="cloud_in1" to="$(arg cloud_in1)" />
     <remap from="cloud_in2" to="$(arg cloud_in2)" />
     <remap from="cloud_in3" to="$(arg cloud_in3)" />

--- a/src/pointcloud_concatenate.cpp
+++ b/src/pointcloud_concatenate.cpp
@@ -112,7 +112,7 @@ bool PointcloudConcatenate::checkTimeThresholdOk(ros::Time& reference_time, ros:
 
 void PointcloudConcatenate::concatenate_with_reference_cloud(sensor_msgs::PointCloud2& reference_cloud, const sensor_msgs::PointCloud2 cloud_to_concat, bool& success, bool& cloud_received_recent, ros::Time& reference_time, ros::Time& current_time, const int& cloud_index, const bool& update_reference_time) {
   // ROS_INFO cloud idx
-  ROS_INFO("Concatenating cloud %d", cloud_index);
+  // ROS_INFO("Concatenating cloud %d", cloud_index);
   if (param_clouds_ >= cloud_index && success && cloud_received_recent) {
       // Warn if cloud was not received since last update
       if (!cloud_received_recent) {
@@ -130,24 +130,24 @@ void PointcloudConcatenate::concatenate_with_reference_cloud(sensor_msgs::PointC
         sensor_msgs::PointCloud2 transformed_cloud;
         // Transform pointcloud to the target frame if needed
         if (cloud_to_concat.header.frame_id != param_frame_target_) {
-          ROS_INFO("Transforming cloud %d from %s to %s", cloud_index, cloud_to_concat.header.frame_id.c_str(), param_frame_target_.c_str());
+          // ROS_INFO("Transforming cloud %d from %s to %s", cloud_index, cloud_to_concat.header.frame_id.c_str(), param_frame_target_.c_str());
           success = pcl_ros::transformPointCloud(param_frame_target_, cloud_to_concat, transformed_cloud, *tfBuffer);
           if (!success) {
             ROS_WARN("Transforming cloud %d from %s to %s failed!", cloud_index, cloud_to_concat.header.frame_id.c_str(), param_frame_target_.c_str());
             return;
           }
         } else {
-          ROS_INFO("Cloud %d is already in the target frame", cloud_index);
+          // ROS_INFO("Cloud %d is already in the target frame", cloud_index);
           transformed_cloud = cloud_to_concat;
         }
         // For the first cloud, set the header and assign directly
         if (update_reference_time) {
           reference_cloud = transformed_cloud;
-          ROS_INFO("Cloud %d is the first cloud. Taken as reference", cloud_index);
+          // ROS_INFO("Cloud %d is the first cloud. Taken as reference", cloud_index);
         } else {
           // Concatenate the pointclouds (all in the same frame now)
           pcl::concatenatePointCloud(reference_cloud, transformed_cloud, reference_cloud);
-          ROS_INFO("Cloud %d is concatenated with the reference cloud wrt the target frame: %s", cloud_index, param_frame_target_.c_str());
+          // ROS_INFO("Cloud %d is concatenated with the reference cloud wrt the target frame: %s", cloud_index, param_frame_target_.c_str());
         }
       }
     }


### PR DESCRIPTION
* `time_threshold` - [double]
  Sets the maximum time difference allowed between pointcloud timestamps for synchronization and fusion.
  Pointclouds with timestamps exceeding this threshold from the reference cloud will not be included in the concatenation.
  Default value: `0.1` seconds.
